### PR TITLE
Fix project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .direnv/
+result

--- a/Main.hs
+++ b/Main.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Prelude
+
+import Reflex.Dom
+
+main :: IO ()
+main = mainWidget $ display =<< count =<< button "ClickMe"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+```
+nix build
+./result/bin/test2
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+# Help-Nix
+
+## Build Project With Cabal in Nix Environment
+
+```
+nix develop
+```
+
+### GHC-JS
+
+```
+js-unknown-ghcjs-cabal build
+# Open ./dist-newstyle/build/js-ghcjs/ghcjs-8.10.7/test2-0.1.0.0/x/test2/build/test2/test2.jsexe/index.html in browser
+```
+
+### GTK
+
+```
+cabal build
+./dist-newstyle/build/x86_64-linux/ghc-8.10.7/test2-0.1.0.0/x/test2/build/test2/test2
+
+OR
+
+cabal run
+```
+
+## Build Project With Nix
+
+### GTK
 ```
 nix build
 ./result/bin/test2

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,21 @@
+index-state: 2022-03-30T00:00:00Z
+
+packages:
+    ./
+
+allow-newer:
+    -- With monoidal-containers-0.6.0.1, there is an issue deriving Eq1:
+    --   - src/Data/HashMap/Monoidal.hs:74:16: error:
+    --       • Could not deduce (Data.Functor.Classes.Eq1 (MonoidalHashMap k)) ...
+    --
+    -- This is fixed in monoidal-containers-0.6.2.0.
+    --
+    -- We can't use monoidal-containers-0.6.2.0 however because it requires:
+    --   - witherable >=0.4 && <0.5
+    -- and reflex-0.8.2.0 requires:
+    --   - witherable >=0.3 && <0.4
+    --
+    -- However, we can allow reflex to use a newer version of witherable to work
+    -- around this problem. It appears the upper bound on witherable in reflex
+    -- is overzealous anyway.
+    reflex:witherable

--- a/flake.lock
+++ b/flake.lock
@@ -133,11 +133,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1656551635,
-        "narHash": "sha256-aH1JzWRmdT7H7Yjaj4xNX4zGLfhIyxK/jikCCZbFRXQ=",
+        "lastModified": 1656724378,
+        "narHash": "sha256-JdtnbKzKiP1GMWuVt3aQYELxFb8A2OhH/TJBfPn3QMg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "85abfa4e6089a0c14241f613c0229c376df4072d",
+        "rev": "6e2d054b0876d3f9709da1df9dfe27325886927e",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1649141593,
-        "narHash": "sha256-9USYJIOvkMpOu4xmp8fp7p8VYNz8REy/oRbPN5nhTKY=",
+        "lastModified": 1656465809,
+        "narHash": "sha256-LKYju7zytD91anOLH5AHEMlX2KlgDqfBMKv3RcrL67I=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "9987a666f2fba42c330cb6ad35d7deb102264d9a",
+        "rev": "c5c44f4027fc4d2fb63acf06d4b1852965caf8e1",
         "type": "github"
       },
       "original": {
@@ -262,11 +262,11 @@
     "nix-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
         "type": "github"
       },
       "original": {
@@ -399,11 +399,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1649034935,
-        "narHash": "sha256-QVnuwt+rC2hzbrLq6PjUjkRHxk3iPjC98GT1v92jfp8=",
+        "lastModified": 1656638371,
+        "narHash": "sha256-waxiLSFvKxpaG4zl8YpLtuhLf5OrFi6CgAIZAOXpnQ8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "0b47e88ff3416adb726b067a33ec0d385df4735e",
+        "rev": "4f1ad0f4b0f01010df8dab254fc8b453934823e7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -392,7 +392,7 @@
         "haskellNix": "haskellNix",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-2111"
+          "nixpkgs-2105"
         ]
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,102 +1,388 @@
 {
   "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656465652,
+        "narHash": "sha256-4722jK3YyWS/rqHzqhl0BMAKQ1zYU2gO2M1Xv5OsxOw=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "d18817ee70bb9c60696ba962378f6d7ab7f21a9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
         "type": "github"
       }
     },
     "haskellNix": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-utils": "flake-utils_2",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "nix-tools": "nix-tools",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2009": "nixpkgs-2009",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1621732348,
-        "narHash": "sha256-o3Z1cCaioBKEIa5mdHEbWDWA4UXAPoJ1lQ4vHJ+WX0s=",
+        "lastModified": 1656465809,
+        "narHash": "sha256-LKYju7zytD91anOLH5AHEMlX2KlgDqfBMKv3RcrL67I=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "721740e01475d4765a3adeb6f70018acf937ac99",
+        "rev": "c5c44f4027fc4d2fb63acf06d4b1852965caf8e1",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
       }
     },
     "nixpkgs-2003": {
       "locked": {
-        "lastModified": 1607708579,
-        "narHash": "sha256-QyADEDydJJPa8n3xawnA82IJAcZHNNm6Pp5DU7exMr4=",
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
         "repo": "nixpkgs",
-        "rev": "7f73e46625f508a793700f5110b86f1a53341d6e",
         "type": "github"
       }
     },
-    "nixpkgs-2009": {
+    "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1608007629,
-        "narHash": "sha256-lipVFC/a2pzzA5X2ULj64je+fz1JIp2XRrB5qyoizpQ=",
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
         "repo": "nixpkgs",
-        "rev": "f02bf8ffb9a5ec5e8f6f66f1e5544fd2aa1a0693",
         "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1612284693,
-        "narHash": "sha256-efzJNF1jvjK3BMl0gZ0ZaUWcFMv0nLb9AHN/++5+u0U=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "410bbd828cdc6156aecd5bc91772ad3a6b1099c7",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
         "type": "github"
       }
     },
@@ -106,8 +392,24 @@
         "haskellNix": "haskellNix",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-2009"
+          "nixpkgs-2105"
         ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656465743,
+        "narHash": "sha256-ga+cqBHnI22dNoOZoBcRIfLNBxvSW5JdR6TFBGNahdI=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "71449b51342a72e32e27f35a31c0fc39b9d055ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -133,11 +133,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1656465652,
-        "narHash": "sha256-4722jK3YyWS/rqHzqhl0BMAKQ1zYU2gO2M1Xv5OsxOw=",
+        "lastModified": 1656551635,
+        "narHash": "sha256-aH1JzWRmdT7H7Yjaj4xNX4zGLfhIyxK/jikCCZbFRXQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d18817ee70bb9c60696ba962378f6d7ab7f21a9f",
+        "rev": "85abfa4e6089a0c14241f613c0229c376df4072d",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1656465809,
-        "narHash": "sha256-LKYju7zytD91anOLH5AHEMlX2KlgDqfBMKv3RcrL67I=",
+        "lastModified": 1649141593,
+        "narHash": "sha256-9USYJIOvkMpOu4xmp8fp7p8VYNz8REy/oRbPN5nhTKY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c5c44f4027fc4d2fb63acf06d4b1852965caf8e1",
+        "rev": "9987a666f2fba42c330cb6ad35d7deb102264d9a",
         "type": "github"
       },
       "original": {
@@ -262,11 +262,11 @@
     "nix-tools": {
       "flake": false,
       "locked": {
-        "lastModified": 1649424170,
-        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
         "type": "github"
       },
       "original": {
@@ -392,18 +392,18 @@
         "haskellNix": "haskellNix",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-2105"
+          "nixpkgs-2111"
         ]
       }
     },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1656465743,
-        "narHash": "sha256-ga+cqBHnI22dNoOZoBcRIfLNBxvSW5JdR6TFBGNahdI=",
+        "lastModified": 1649034935,
+        "narHash": "sha256-QVnuwt+rC2hzbrLq6PjUjkRHxk3iPjC98GT1v92jfp8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "71449b51342a72e32e27f35a31c0fc39b9d055ff",
+        "rev": "0b47e88ff3416adb726b067a33ec0d385df4735e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,23 +5,34 @@
     url = "github:input-output-hk/haskell.nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
-  inputs.nixpkgs.follows = "haskellNix/nixpkgs-2105";
+  inputs.nixpkgs.follows = "haskellNix/nixpkgs-2111";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, haskellNix, flake-utils }:
     builtins.trace haskellNix (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         overlays = [ haskellNix.overlay (final: prev: {
-        test2 = final.haskell-nix.project' {
-          src = ./.;
-          compiler-nix-name = "ghc8107";
-          modules = [
-            { packages.webkit2gtk3-javascriptcore.doHaddock = false; }
-          ];
-        };
+          test2 = final.haskell-nix.project' ( { lib, ... }: {
+            src = ./.;
+            compiler-nix-name = "ghc8107";
+            modules = [
+              { packages.webkit2gtk3-javascriptcore.doHaddock = false; }
+            ];
+
+            shell = {
+              name = "dev-shell";
+              packages = ps: [ ps.test2 ];
+
+              crossPlatforms = p: [ p.ghcjs ];
+
+              meta.platforms = lib.platforms.unix;
+            };
+          });
 	      }) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        flake = pkgs.test2.flake {};
+        flake = pkgs.test2.flake {
+              crossPlatforms = p: with p; [ ghcjs ];
+        };
       in
         flake // {
           defaultPackage = flake.packages."test2:exe:test2";

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,13 @@
     builtins.trace haskellNix (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         overlays = [ haskellNix.overlay (final: prev: {
-	  test2 = final.haskell-nix.project' {
-	    src = ./.;
-	    compiler-nix-name = "ghc8104";
-          };
+        test2 = final.haskell-nix.project' {
+          src = ./.;
+          compiler-nix-name = "ghc8104";
+          modules = [
+            { packages.webkit2gtk3-javascriptcore.doHaddock = false; }
+          ];
+        };
 	}) ];
         pkgs = import nixpkgs { inherit system overlays; };
         flake = pkgs.test2.flake {};

--- a/flake.nix
+++ b/flake.nix
@@ -12,22 +12,45 @@
     builtins.trace haskellNix (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         overlays = [ haskellNix.overlay (final: prev: {
-          test2 = final.haskell-nix.project' ( { lib, ... }: {
-            src = ./.;
-            compiler-nix-name = "ghc8107";
-            modules = [
-              { packages.webkit2gtk3-javascriptcore.doHaddock = false; }
-            ];
+          test2 = final.haskell-nix.project' ( { pkgs, lib, ... }:
+            let
+              inherit (pkgs) stdenv;
+              isCrossBuild = stdenv.hostPlatform != stdenv.buildPlatform;
+            in
+              {
+                src = ./.;
+                compiler-nix-name = "ghc8107";
+                modules = [
+                  # Haddock generation for webkit2gtk3 fails with:
+                  # Setup: Graphics/UI/Gtk/WebKit/JavaScriptCore/JSValueRef.chi not found in:
+                  # /nix/store/a2xpbp9v6qlkq9zh2bcsbfslb5nvc0rd-ghc-8.10.7/lib/ghc-8.10.7/base-4.14.3.0
+                  # dist/build
+                  # .
+                  #
+                  # See https://github.com/gtk2hs/webkit-javascriptcore/issues/6
+                  { packages.webkit2gtk3-javascriptcore.doHaddock = false; }
+                  # After haskell.nix revision
+                  # 95faec6038f6684e4ef2a9476216bc1f72d44ffd (first bad commit), we
+                  # started to see the error:
+                  #
+                  # Package key for wired-in dependency `ghcjs-th' could not be found:
+                  # ghcjs-th-0.1.0.0-JdGbYrK1CstBZz9Zn9tGjt
+                  #
+                  # We need to set reinstallableLibGhc to false to workaround this
+                  # (the default changed from false to true in this commit):
+                  (lib.mkIf isCrossBuild { reinstallableLibGhc = false; })
+                ];
 
-            shell = {
-              name = "dev-shell";
-              packages = ps: [ ps.test2 ];
+                shell = {
+                  name = "dev-shell";
+                  packages = ps: [ ps.test2 ];
 
-              crossPlatforms = p: [ p.ghcjs ];
+                  crossPlatforms = p: [ p.ghcjs ];
 
-              meta.platforms = lib.platforms.unix;
-            };
-          });
+                  meta.platforms = lib.platforms.unix;
+                };
+              }
+          );
 	      }) ];
         pkgs = import nixpkgs { inherit system overlays; };
         flake = pkgs.test2.flake {

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,30 @@
 {
   description = "testicles";
 
-  inputs.haskellNix.url  = "github:input-output-hk/haskell.nix";
-  inputs.nixpkgs.follows = "haskellNix/nixpkgs-2009";
+  inputs.haskellNix = {
+    url = "github:input-output-hk/haskell.nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  inputs.nixpkgs.follows = "haskellNix/nixpkgs-2105";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  
+
   outputs = { self, nixpkgs, haskellNix, flake-utils }:
     builtins.trace haskellNix (flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         overlays = [ haskellNix.overlay (final: prev: {
         test2 = final.haskell-nix.project' {
           src = ./.;
-          compiler-nix-name = "ghc8104";
+          compiler-nix-name = "ghc8107";
           modules = [
             { packages.webkit2gtk3-javascriptcore.doHaddock = false; }
           ];
         };
-	}) ];
+	      }) ];
         pkgs = import nixpkgs { inherit system overlays; };
         flake = pkgs.test2.flake {};
       in
         flake // {
           defaultPackage = flake.packages."test2:exe:test2";
-	}
+        }
     ));
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     url = "github:input-output-hk/haskell.nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
-  inputs.nixpkgs.follows = "haskellNix/nixpkgs-2111";
+  inputs.nixpkgs.follows = "haskellNix/nixpkgs-2105";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, haskellNix, flake-utils }:


### PR DESCRIPTION
Hey  @patr-ck!

I was attempting to get a reflex project working with haskell.nix as well when I found your repository. It's taken me some time, but I've managed to modify your repository to do a few things:

- Workaround https://github.com/gtk2hs/webkit-javascriptcore/issues/6, which you reported on IRC.
- Provide a GHCJS compiler in the shell.
- Update haskell.nix to a recent version, updating the configuration as required (see `reinstallableLibGhc`).
- Add a working Reflex example.
- Add some documentation.

I hope this is helpful.